### PR TITLE
Slightly refactored code of Usercard.

### DIFF
--- a/src/widgets/dialogs/UserInfoPopup.hpp
+++ b/src/widgets/dialogs/UserInfoPopup.hpp
@@ -34,8 +34,6 @@ private:
     bool isMod_;
     bool isBroadcaster_;
 
-    static int calculateTimeoutDuration(const QString &durationPerUnit, const QString &unit);
-
     QString userName_;
     QString userId_;
     ChannelPtr channel_;

--- a/src/widgets/settingspages/AdvancedPage.hpp
+++ b/src/widgets/settingspages/AdvancedPage.hpp
@@ -11,12 +11,12 @@ public:
 
 private:
     // list needed for dynamic timeout settings
-    QList<QLineEdit *> durationInputs;
-    QList<QComboBox *> unitInputs;
+    QList<QLineEdit *> durationInputs_;
+    QList<QComboBox *> unitInputs_;
 
     // iterators used in dynamic timeout settings
-    QList<QLineEdit *>::iterator itDurationInput;
-    QList<QComboBox *>::iterator itUnitInput;
+    QList<QLineEdit *>::iterator itDurationInput_;
+    QList<QComboBox *>::iterator itUnitInput_;
 
 private slots:
     void timeoutDurationChanged(const QString &newDuration);


### PR DESCRIPTION
Hey @TranRed, nice [pull request](https://github.com/Chatterino/chatterino2/pull/1238).

I had some thoughts about the refactoring and decided that it would be quicker to create a commit for you than to write every single change suggestion.

Changes:
- `calculateTimeoutDuration` moved to an anonymous namespace. There is no reason to hold this function as a class method.
- Moved `QColor borderColor(255, 255, 255, 80);` to a single place and signed it as `const`.
- A manually creation of `std::vector<std::pair<QString, int>>` for the timeouts was replaced with quicker `std::generate`.
- Any reference to a class field must be accompanied by `this->`. (It is required by fourtf.)
- Other little things.

What you think?

P.S.: If you accept this PR, it's better to do it by rebasing, not merging.