### PR TITLE
Considerably refactored code of Usercard.

### DIFF
--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -9,6 +9,8 @@
 #include <pajlada/settings/setting.hpp>
 #include <pajlada/settings/settinglistener.hpp>
 
+using TimeoutButton = std::pair<QString, int>;
+
 namespace chatterino {
 
 class Settings : public ABSettings
@@ -197,8 +199,10 @@ public:
 
     /// Timeout buttons
 
-    ChatterinoSetting<std::vector<QString>> timeoutDurationsPerUnit = { "/timeouts/timeoutDurationsPerUnit", { "1", "30", "1", "5", "30", "1", "1", "1" }};
-    ChatterinoSetting<std::vector<QString>> timeoutDurationUnits = { "/timeouts/timeoutDurationUnits", { "s", "s", "m", "m", "m", "h", "d", "w" }};
+    ChatterinoSetting<std::vector<TimeoutButton>> timeoutButtons = {
+        "/timeouts/timeoutButtons",
+            { { "s", 1 },  { "s", 30 }, { "m", 1 }, { "m", 5 },
+              { "m", 30 }, { "h", 1 },  { "d", 1 }, { "w", 1 } } };
 
 private:
     void updateModerationActions();

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -34,13 +34,12 @@ namespace {
 
 const auto kBorderColor = QColor(255, 255, 255, 80);
 
-int calculateTimeoutDuration(const QString &durationPerUnit,
-                             const QString &unit)
+int calculateTimeoutDuration(int durationPerUnit, const QString &unit)
 {
     static const QMap<QString, int> durations{
         {"s", 1}, {"m", 60}, {"h", 3600}, {"d", 86400}, {"w", 604800},
     };
-    return durationPerUnit.toInt() * durations[unit];
+    return durationPerUnit * durations[unit];
 }
 
 }  // namespace
@@ -555,18 +554,15 @@ UserInfoPopup::TimeoutWidget::TimeoutWidget()
 
     addButton(Unban, "unban", getApp()->resources->buttons.unban);
 
-    std::vector<QString> durationsPerUnit =
-        getSettings()->timeoutDurationsPerUnit;
 
-    std::vector<QString> durationUnits = getSettings()->timeoutDurationUnits;
-
+    const auto timeoutButtons = getSettings()->timeoutButtons.getValue();
     std::vector<std::pair<QString, int>> t(8);  // Timeouts.
     auto i = 0;
-
     std::generate(t.begin(), t.end(), [&] {
+        const auto tButton = timeoutButtons[i];
         std::pair<QString, int> pair = std::make_pair(
-            durationsPerUnit[i] + durationUnits[i],
-            calculateTimeoutDuration(durationsPerUnit[i], durationUnits[i]));
+            QString::number(tButton.second) + tButton.first,
+            calculateTimeoutDuration(tButton.second, tButton.first));
         i++;
         return pair;
     });
@@ -593,8 +589,7 @@ void UserInfoPopup::fillLatestMessages()
     for (size_t i = 0; i < snapshot.size(); i++)
     {
         MessagePtr message = snapshot[i];
-        if (message->loginName.compare(this->userName_, Qt::CaseInsensitive) ==
-                0 &&
+        if (!message->loginName.compare(this->userName_, Qt::CaseInsensitive) &&
             !message->flags.has(MessageFlag::Whisper))
         {
             channelPtr->addMessage(message);

--- a/src/widgets/settingspages/AdvancedPage.hpp
+++ b/src/widgets/settingspages/AdvancedPage.hpp
@@ -11,16 +11,9 @@ public:
 
 private:
     // list needed for dynamic timeout settings
-    QList<QLineEdit *> durationInputs_;
-    QList<QComboBox *> unitInputs_;
+    std::vector<QLineEdit *> durationInputs_;
+    std::vector<QComboBox *> unitInputs_;
 
-    // iterators used in dynamic timeout settings
-    QList<QLineEdit *>::iterator itDurationInput_;
-    QList<QComboBox *>::iterator itUnitInput_;
-
-private slots:
-    void timeoutDurationChanged(const QString &newDuration);
-    void timeoutUnitChanged(const QString &newUnit);
 };
 
 }  // namespace chatterino


### PR DESCRIPTION
Hi again, @TranRed.

I'm sorry about the std::generate that was causing the crash. =)

I looked a little deeper into the code and found that some things are too complicated.

- Two different setting vectors can be combined into a single vector with `std::pair<QString, int>` named as `TimeoutUnit`.
- `timeoutDurationChanged` and `timeoutUnitChanged` slots actually work pretty much the same way and can be combined into a single lambda.
- We do not need to use an additional `for` loop to fill the QList with empty objects. We can do it together with setting up of the objects.
- I don't see any use for iterators. We can access the required object from the list using the index. So I deleted all the code associated with the iterators. IMHO it's the key thing that made the code more complicated.

Other little things:
- `unitsForDropdown` was moved to `timeoutDurationUnit->addItems`.
- `"Button " + QString::number(i + 1) + ": "` was replaced with `QString("Button %1: ").arg(i + 1)`.
- `QList<QComboBox\QLineEdit *>` was replaced with std::vectors, just why not. =)

I think the code has become simpler.